### PR TITLE
Adding test coverage to GitHub actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,8 +19,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install Dependencies
-        run: pip install pytest
+        run: |
+          pip install pytest
+          pip install pytest-cov
       - name: Checkout py-mms
         uses: actions/checkout@v2
       - name: Run Tests
-        run: pytest -v
+        run: pytest -v --cov=pymms

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ __pycache__
 
 # Pytest
 .pytest_cache
+.coverage
 tests/temp/


### PR DESCRIPTION
Currently returns the results in the test job itself, but doesn't report to any external tool. Not sure if we want that?
```
Run pytest -v --cov=pymms
============================= test session starts ==============================
platform linux -- Python 3.5.9, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /opt/hostedtoolcache/Python/3.5.9/x64/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/py-mms/py-mms, configfile: pytest.ini
plugins: cov-2.10.1
collecting ... collected 1 item

tests/test_core.py::testConfigInit PASSED                                [100%]

----------- coverage: platform linux, python 3.5.9-final-0 -----------
Name                Stmts   Miss  Cover
---------------------------------------
pymms/__init__.py       5      0   100%
pymms/pymms.py          6      0   100%
---------------------------------------
TOTAL                  11      0   100%


============================== 1 passed in 0.06s ===============================
```