### PR TITLE
Issue #11: ProductEvent changes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Start mmsd
         run: |
           cd pymms/lib/go-mms
-          ../mmsd
+          ../mmsd &
       - name: Run Tests
         run: pytest -v --cov=pymms
       - name: Upload to Codecov
@@ -59,6 +59,6 @@ jobs:
       - name: Start mmsd
         run: |
           cd pymms/lib/go-mms
-          ../mmsd
+          ../mmsd &
       - name: Run Tests
         run: pytest -v

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           git submodule update --init
           ./makeLib.sh
+      - name: Start mmsd
+        run: |
+          cd pymms/lib/go-mms
+          ../mmsd
       - name: Run Tests
         run: pytest -v --cov=pymms
       - name: Upload to Codecov
@@ -52,5 +56,9 @@ jobs:
         run: |
           git submodule update --init
           ./makeLib.sh
+      - name: Start mmsd
+        run: |
+          cd pymms/lib/go-mms
+          ../mmsd
       - name: Run Tests
         run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tests/temp/
 # Go
 /pymms/lib/lib*.h
 /pymms/lib/lib*.so
+/pymms/lib/mms
+/pymms/lib/mmsd

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,3 @@
-
 codecov:
   require_ci_to_pass: yes
 
@@ -15,5 +14,13 @@ coverage:
       default:
         threshold: 1%
     changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
 
 comment: false

--- a/makeLib.sh
+++ b/makeLib.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
 cd pymms/lib/go-mms
-go build -o libmms.so -buildmode=c-shared ./export
+
+go build -v -o libmms.so -buildmode=c-shared ./export
+go build -v ./cmd/mmsd
+go build -v ./cmd/mms
+
 mv libmms.* ../
+mv mmsd ../
+mv mms ../

--- a/pymms/__init__.py
+++ b/pymms/__init__.py
@@ -30,27 +30,41 @@ _CONFIG = Config()
 
 from .pymms import PyMMS # noqa: E402
 from .productevent import ProductEvent # noqa: E402
+from .exceptions import MMSError # noqa: E402
 
 __package__ = "pymms"
 __version__ = "0.0.1"
 
-__all__ = ["PyMMS", "ProductEvent"]
+__all__ = ["PyMMS", "ProductEvent", "MMSError"]
 
 # Initiating logging
-strLevel = os.environ.get("PYMMS_LOGLEVEL", "INFO")
-if hasattr(logging, strLevel):
-    logLevel = getattr(logging, strLevel)
-else:
-    print("Invalid logging level '%s' in environment variable PYMMS_LOGLEVEL" % strLevel)
-    logLevel = logging.INFO
+def _initLogging(logObj):
+    strLevel = os.environ.get("PYMMS_LOGLEVEL", "INFO")
+    if hasattr(logging, strLevel):
+        logLevel = getattr(logging, strLevel)
+    else:
+        print("Invalid logging level '%s' in environment variable PYMMS_LOGLEVEL" % strLevel)
+        logLevel = logging.INFO
 
-if logLevel < logging.INFO:
-    logFormat = "[{asctime:s}] {levelname:8s} {message:}"
-else:
-    logFormat = "{levelname:8s} {message:}"
+    if logLevel < logging.INFO:
+        logFormat = "[{asctime:s}] {levelname:8s} {message:}"
+    else:
+        logFormat = "{levelname:8s} {message:}"
 
-logging.basicConfig(format=logFormat, style="{", level=logLevel)
+    logFmt = logging.Formatter(fmt=logFormat, style="{")
+
+    cHandle = logging.StreamHandler()
+    cHandle.setLevel(logLevel)
+    cHandle.setFormatter(logFmt)
+
+    logObj.setLevel(logLevel)
+    logObj.addHandler(cHandle)
+
+    return
+
+# Logging Setup
 logger = logging.getLogger(__name__)
+_initLogging(logger)
 
 # Initialise Config
 _CONFIG.initConfig()

--- a/pymms/gomms.py
+++ b/pymms/gomms.py
@@ -62,9 +62,6 @@ class GoMMS():
         else:
             raise MMSError("Invalid return data from libmms.so")
 
-        # print("Python received message:")
-        # print(retDict)
-
         return retDict
 
     def sayHello(self):

--- a/pymms/gomms.py
+++ b/pymms/gomms.py
@@ -43,13 +43,13 @@ class GoMMS():
 
         return
 
-    def productEvent(self, product, productSlug, productionHub):
+    def productEvent(self, product, productionHub, productLocation):
         """Post an event to the MMS client.
         """
         payLoad = json.dumps({
-            "Product":       str(product),
-            "ProductSlug":   str(productSlug),
-            "ProductionHub": str(productionHub),
+            "Product":         str(product),
+            "ProductionHub":   str(productionHub),
+            "ProductLocation": str(productLocation),
         })
         self.goLib.PyProductEvent.restype = ctypes.c_char_p
         retData = self.goLib.PyProductEvent(payLoad.encode()).decode()

--- a/pymms/productevent.py
+++ b/pymms/productevent.py
@@ -29,14 +29,14 @@ class ProductEvent():
     """Wrapper class for the go-mms product event.
     """
 
-    def __init__(self, product="", productSlug="", productionHub=""):
+    def __init__(self, product="", productionHub="", productLocation=""):
 
         self._goMMS = GoMMS()
 
         # Event properties
         self._eventProduct = product
-        self._eventProductSlug = productSlug
         self._eventProductionHub = productionHub
+        self._eventProductLocation = productLocation
 
         return
 
@@ -49,12 +49,12 @@ class ProductEvent():
         return self._eventProduct
 
     @property
-    def productSlug(self):
-        return self._eventProductSlug
-
-    @property
     def productionHub(self):
         return self._eventProductionHub
+
+    @property
+    def productLocation(self):
+        return self._eventProductLocation
 
     ##
     #  Setters
@@ -69,15 +69,6 @@ class ProductEvent():
             raise ValueError("ProductEvent.product must be a string")
         return
 
-    @productSlug.setter
-    def productSlug(self, value):
-        if isinstance(value, str):
-            self._eventProductSlug = value
-        else:
-            self._eventProductSlug = ""
-            raise ValueError("ProductEvent.productSlug must be a string")
-        return
-
     @productionHub.setter
     def productionHub(self, value):
         if isinstance(value, str):
@@ -85,6 +76,15 @@ class ProductEvent():
         else:
             self._eventProductionHub = ""
             raise ValueError("ProductEvent.productionHub must be a string")
+        return
+
+    @productLocation.setter
+    def productLocation(self, value):
+        if isinstance(value, str):
+            self._eventProductLocation = value
+        else:
+            self._eventProductLocation = ""
+            raise ValueError("ProductEvent.productLocation must be a string")
         return
 
     ##
@@ -97,8 +97,8 @@ class ProductEvent():
         """
         retData = self._goMMS.productEvent(
             product=self._eventProduct,
-            productSlug=self._eventProductSlug,
-            productionHub=self._eventProductionHub
+            productionHub=self._eventProductionHub,
+            productLocation=self._eventProductLocation
         )
         return retData
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,9 +2,23 @@
 """Core object tests.
 """
 
+import os
 import pytest
+import logging
 
-from pymms import PyMMS
+from pymms import PyMMS, _initLogging
+
+@pytest.mark.core
+def testInitLogging():
+    os.environ["PYMMS_LOGLEVEL"] = "DEBUG"
+    logger = logging.getLogger(__name__)
+    _initLogging(logger)
+    assert logger.getEffectiveLevel() == logging.DEBUG
+
+    os.environ["PYMMS_LOGLEVEL"] = "INVALID"
+    logger = logging.getLogger(__name__)
+    _initLogging(logger)
+    assert logger.getEffectiveLevel() == logging.INFO
 
 @pytest.mark.core
 def testConfigInit():

--- a/tests/test_postevent.py
+++ b/tests/test_postevent.py
@@ -8,25 +8,29 @@ from pymms import ProductEvent
 
 @pytest.mark.events
 def testCreateProductEvent():
-    pEvent = ProductEvent("FirstA", "FirstB", "FirstC")
+    pEvent = ProductEvent(
+        product="FirstA",
+        productionHub="FirstB",
+        productLocation="FirstC"
+    )
 
     assert pEvent.product == "FirstA"
-    assert pEvent.productSlug == "FirstB"
-    assert pEvent.productionHub == "FirstC"
+    assert pEvent.productionHub == "FirstB"
+    assert pEvent.productLocation == "FirstC"
 
     with pytest.raises(ValueError):
         pEvent.product = 0
 
     with pytest.raises(ValueError):
-        pEvent.productSlug = 1
+        pEvent.productionHub = 1
 
     with pytest.raises(ValueError):
-        pEvent.productionHub = 2
+        pEvent.productLocation = 2
 
     pEvent.product = "SecondA"
-    pEvent.productSlug = "SecondB"
-    pEvent.productionHub = "SecondC"
+    pEvent.productionHub = "SecondB"
+    pEvent.productLocation = "SecondC"
 
     assert pEvent.product == "SecondA"
-    assert pEvent.productSlug == "SecondB"
-    assert pEvent.productionHub == "SecondC"
+    assert pEvent.productionHub == "SecondB"
+    assert pEvent.productLocation == "SecondC"

--- a/tests/test_postevent.py
+++ b/tests/test_postevent.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pymms import ProductEvent
+from pymms import ProductEvent, MMSError
 
 @pytest.mark.events
 def testCreateProductEvent():
@@ -34,3 +34,20 @@ def testCreateProductEvent():
     assert pEvent.product == "SecondA"
     assert pEvent.productionHub == "SecondB"
     assert pEvent.productLocation == "SecondC"
+
+@pytest.mark.events
+def testSendProductEvent():
+    # Valid Event
+    pEvent = ProductEvent(
+        product="Test",
+        productionHub="test-hub",
+        productLocation="/tmp"
+    )
+    retData = pEvent.send()
+    assert not retData["err"]
+    assert not retData["errmsg"]
+
+    # Invalid Event
+    pEvent.productionHub = "no-such-hub"
+    with pytest.raises(MMSError):
+        retData = pEvent.send()


### PR DESCRIPTION
This PR:

* brings `py-mms` in sync with the changes to the `ProductEvent` struct in `go-mms`,
* rewrites logger initialisation so it can be covered by tests,
* adds test coverage of ProductEvent.send()
