### PR TITLE
Full Coverage!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 # Pytest
 .pytest_cache
 .coverage
+htmlcov/
 tests/temp/
 
 # Go

--- a/README.md
+++ b/README.md
@@ -5,3 +5,49 @@
 [![codecov](https://codecov.io/gh/metno/py-mms/branch/master/graph/badge.svg)](https://codecov.io/gh/metno/py-mms)
 
 Python client for MET Messaging System (MMS).
+
+## Clone and Build
+
+To use the `py-mms` package from source, please run the following:
+```bash
+git clone https://github.com/metno/py-mms
+cd py-mms
+git submodule update --init
+./makeLib.sh
+```
+
+This will clone the `py-mms` repository, with the `go-mms` repository as a submodule.
+The `makeLib.sh` script builds a shared library version of the `go-mms` tool.
+This is required for the `py-mms` package to work.
+
+## How to Use
+
+Currently, `py-mms` only contains a wrapper for sending MMS product events via the `go-mms` tool.
+Here's a usage example:
+```Python
+from pymms import ProductEvent, MMSError
+
+pEvent = ProductEvent(
+    product="Test",
+    productionHub="test-hub",
+    productLocation="/tmp"
+)
+
+try:
+    retData = pEvent.send()
+except MMSError as err:
+    print(f"Error: {err}")
+```
+
+## Tests
+
+The tests can be run with `pytest`. For full details and coverage report, run
+```bash
+pytest -v --cov=pymms
+```
+from the root folder. Alternatively, you may need to use `pytest-3` on some systems with both Python 2 and 3 as `pytest` often defaults to the Python 2 version.
+
+The coverage report requires the package `pytest-cov` to be installed.
+
+**Note:** The tests require the MMD daemon to be running. You can either run it from the `pymms/lib/go-mms` folder,
+or from the [go-mms](https://github.com/metno/go-mms) source. It currently has to be run from the root folder of `go-mms` due to a dependence on template files in the `go-mms` repository. See [go-mms issue #31](https://github.com/metno/go-mms/issues/31).

--- a/pymms/gomms.py
+++ b/pymms/gomms.py
@@ -19,14 +19,12 @@
  limitations under the License.
 """
 
-import json
 import ctypes
 import logging
 
 from os import path
 
 from . import _CONFIG
-from .exceptions import MMSError
 
 logger = logging.getLogger(__name__)
 
@@ -43,26 +41,11 @@ class GoMMS():
 
         return
 
-    def productEvent(self, product, productionHub, productLocation):
+    def productEvent(self, payLoad):
         """Post an event to the MMS client.
         """
-        payLoad = json.dumps({
-            "Product":         str(product),
-            "ProductionHub":   str(productionHub),
-            "ProductLocation": str(productLocation),
-        })
         self.goLib.PyProductEvent.restype = ctypes.c_char_p
-        retData = self.goLib.PyProductEvent(payLoad.encode()).decode()
-        retDict = json.loads(retData)
-
-        if "err" in retDict and "errmsg" in retDict:
-            if retDict["err"]:
-                errMsg = retDict["errmsg"].replace(": ", ":\n")
-                raise MMSError("\n%s" % errMsg.strip())
-        else:
-            raise MMSError("Invalid return data from libmms.so")
-
-        return retDict
+        return self.goLib.PyProductEvent(payLoad.encode()).decode()
 
     def sayHello(self):
         """Function to check that the interface to the go-mms client is

--- a/tests/test_postevent.py
+++ b/tests/test_postevent.py
@@ -5,6 +5,7 @@
 import pytest
 
 from pymms import ProductEvent, MMSError
+from pymms.gomms import GoMMS
 
 @pytest.mark.events
 def testCreateProductEvent():
@@ -36,7 +37,7 @@ def testCreateProductEvent():
     assert pEvent.productLocation == "SecondC"
 
 @pytest.mark.events
-def testSendProductEvent():
+def testSendProductEvent(monkeypatch):
     # Valid Event
     pEvent = ProductEvent(
         product="Test",
@@ -49,5 +50,10 @@ def testSendProductEvent():
 
     # Invalid Event
     pEvent.productionHub = "no-such-hub"
+    with pytest.raises(MMSError):
+        retData = pEvent.send()
+
+    # Invalid Return
+    monkeypatch.setattr(GoMMS, "productEvent", lambda self, payLoad: r"{}")
     with pytest.raises(MMSError):
         retData = pEvent.send()


### PR DESCRIPTION
This PR moves all the string-to-json code, with checks, out of the `GoMMS` library wrapper and into the `ProductEvent` class. This means we can monkeypatch the whole `GoMMS` class in order to test also a faulty return from `GoMMS` and therefore also get the final code line covered by tests.