### PR TITLE
Time format fix for updated mmsd in ProductEvent

### DIFF
--- a/pymms/productevent.py
+++ b/pymms/productevent.py
@@ -171,14 +171,13 @@ class ProductEvent():
         """
         nowTime = datetime.now().astimezone()
         nextTime = nowTime + timedelta(seconds=self._eventInterval)
-
         payLoad = json.dumps({
             "JobName":         str(self._eventJobName),
             "Product":         str(self._eventProduct),
             "ProductionHub":   str(self._eventProductionHub),
             "ProductLocation": str(self._eventProductLocation),
-            "CreatedAt":       nowTime.isoformat(),
-            "NextEventAt":     nextTime.isoformat(),
+            "CreatedAt":       nowTime.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            "NextEventAt":     nextTime.strftime('%Y-%m-%dT%H:%M:%SZ'),
             "RefTime":         str(self._refTime),
             "Counter":         self.counter,
             "TotalCount":      self.totalCount


### PR DESCRIPTION
Tested by sending an event to a real server  
```
#!/usr/bin/env python3

from pymms import ProductEvent, MMSError

pEvent = ProductEvent(
    jobName="Job",
    product="Test",
    productionHub="http://localhost:8080",
    productLocation="/tmp",
    eventInterval=3600,
    refTime="2021-06-22T12:00:00Z",
    counter=1,
    totalCount=1
)

try:
    retData = pEvent.send()
except MMSError as err:
    print(f"Error: {err}") 
``` 